### PR TITLE
Check for demo end-of-file (in case of truncated demo)

### DIFF
--- a/src/Demo/Demo.cpp
+++ b/src/Demo/Demo.cpp
@@ -47,7 +47,7 @@ namespace CoD4::DM1
 	{
 		if (DemoFile.is_open())
 		{
-			if (CurrentCompressedMsg.SrvMsgSeq == -1)
+			if (CurrentCompressedMsg.SrvMsgSeq == -1 || DemoFile.eof())
 			{
 				IsEOF = true;
 				return false;
@@ -2178,3 +2178,4 @@ namespace CoD4::DM1
 		return true;
 	}
 }
+


### PR DESCRIPTION
If the demo doesn't have an explicit EOF marker, the program is stuck in an infinite loop. So there needs to be a check for EOF on the file.