### PR TITLE
Check for out-of-bound values 1

### DIFF
--- a/src/Demo/Demo.cpp
+++ b/src/Demo/Demo.cpp
@@ -834,9 +834,10 @@ namespace CoD4::DM1
 			newnum = ReadEntityIndex(msg, GENTITYNUM_BITS);
 			if (newnum == 1023)
 				break;
-			if (msg.ReadCount > msg.CurSize)
+			if (msg.ReadCount > msg.CurSize || static_cast<unsigned int>(newnum) >= 1024)
 			{
 				VerboseLog("Error parsing entities");
+				msg.Overflowed = true;
 				return -1;
 			}
 
@@ -921,9 +922,10 @@ namespace CoD4::DM1
 		{
 			VerboseLog("clientnum: " << newnum << std::endl);
 			newnum = ReadEntityIndex(msg, 6);
-			if (msg.ReadCount > msg.CurSize)
+			if (msg.ReadCount > msg.CurSize || static_cast<unsigned int>(newnum) >= MAX_CLIENTS)
 			{
 				VerboseLog("Error parsing clients");
+				msg.Overflowed = true;
 				return;
 			}
 
@@ -1016,6 +1018,12 @@ namespace CoD4::DM1
 
 		bool readOriginAndVel = SendOriginAndVel = msg.ReadBit() > 0;
 		int lastChangedField = ReadLastChangedField(msg, PLAYER_STATE_FIELDS_COUNT);
+		if (static_cast<unsigned int>(lastChangedField) > PLAYER_STATE_FIELDS_COUNT)
+		{
+			VerboseLog("Error parsing playerstate");
+			msg.Overflowed = true;
+			return;
+		}
 
 		netField_t* stateFields = NetFields::PlayerStateFields;
 		for (int i = 0; i < lastChangedField; ++i)
@@ -2178,3 +2186,4 @@ namespace CoD4::DM1
 		return true;
 	}
 }
+


### PR DESCRIPTION
1. `newnum = ReadEntityIndex(msg, GENTITYNUM_BITS);` can return -1 (if msg overflowed), which is not a valid entity index to be used for arrays.
2. `newnum = ReadEntityIndex(msg, 6);` can return -1 (if msg overflowed), which is not a valid client index to be used for arrays.
3. `int lastChangedField = ReadLastChangedField(msg, PLAYER_STATE_FIELDS_COUNT);` can return up to 255, which exceeds `PLAYER_STATE_FIELDS_COUNT` (141) and may cause OOB reads and / or writes.